### PR TITLE
Submission details pagination

### DIFF
--- a/components/Pagination/index.tsx
+++ b/components/Pagination/index.tsx
@@ -25,6 +25,15 @@ import type { ReactElement } from 'react';
 import { UnStyledButton } from '#components/Button';
 import defaultTheme from '#components/theme';
 
+// utility function
+export const getPaginationRange = (page: number, pageSize: number, dataLength: number) => {
+	const start = (page - 1) * pageSize;
+	return {
+		first: start + 1,
+		last: start + dataLength,
+	};
+};
+
 export const PaginationToolBar = ({
 	goToFirstPage,
 	goToPrevPage,

--- a/components/pages/submission/Clinical/Details/index.tsx
+++ b/components/pages/submission/Clinical/Details/index.tsx
@@ -50,7 +50,7 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 	const { token } = useAuthContext();
 	const { awaitingResponse, fetchMuseData, fetchEventStream } = useMuseData('SubmissionsDetails');
 
-	const pageSize = 20;
+	const pageSize = 50;
 
 	// gets the initial status for all the uploads
 	useEffect(() => {

--- a/components/pages/submission/Environmental/Details/index.tsx
+++ b/components/pages/submission/Environmental/Details/index.tsx
@@ -89,7 +89,7 @@ const SubmissionDetails = ({ ID }: SubmissionDetailsProps): ReactElement => {
 		getAnalysisIds,
 	} = useEnvironmentalData('SubmissionsDetails');
 
-	const pageSize = 20;
+	const pageSize = 50;
 
 	/**
 	 * Marks all records with `PROCESSING` status as `COMPLETE` in the submission details.


### PR DESCRIPTION
## Description
Add pagination to submission details page Display **50 rows** at a time


## Examples
### Dynamic totals on top of the table
<img width="1037" height="189" alt="image" src="https://github.com/user-attachments/assets/93e8c898-f289-4a2b-bbf0-6e24a735fe1a" />


### Page navigation on the bottom of the table
<img width="1037" height="79" alt="image" src="https://github.com/user-attachments/assets/a157a7ec-034e-4e3f-8724-f4591a58b09d" />


## Issues related
- https://github.com/virusseq/roadmap/issues/129